### PR TITLE
Added a conveinience interface to automatically enable praeter in all worlds.

### DIFF
--- a/praeter-core/src/main/java/ca/bkaw/praeter/core/PraeterPlugin.java
+++ b/praeter-core/src/main/java/ca/bkaw/praeter/core/PraeterPlugin.java
@@ -35,4 +35,11 @@ public interface PraeterPlugin {
      * A method called after the packs have been baked.
      */
     default void onPacksBaked() {} // TODO better name
+
+    interface Global extends PraeterPlugin {
+        @Override
+        default boolean isEnabledIn(World world) {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
Just makes your main plugin class a little tidier, if you don't have a need for per world support.